### PR TITLE
Unify configuration behaviour across cards

### DIFF
--- a/src/ui/preact/network_status_component.tsx
+++ b/src/ui/preact/network_status_component.tsx
@@ -269,7 +269,6 @@ export class NetworkStatusComponent
   private handleConfigEnd = () => {
     this.setState({
       ...this.state,
-      expanded: false,
       config: null,
       enableConfiguration: false,
     });
@@ -279,7 +278,6 @@ export class NetworkStatusComponent
   private handleConfigBeginWiFiSta = () => {
     this.setState({
       ...this.state,
-      expanded: true,
       enableConfiguration: true,
       config: this.props.builder.build(NetworkType.WiFiSTA),
     });
@@ -289,7 +287,6 @@ export class NetworkStatusComponent
   private handleConfigBeginWiFiAp = () => {
     this.setState({
       ...this.state,
-      expanded: true,
       enableConfiguration: true,
       config: this.props.builder.build(NetworkType.WiFiAP),
     });

--- a/src/ui/preact/sensor/soil/analog_sensor_component.tsx
+++ b/src/ui/preact/sensor/soil/analog_sensor_component.tsx
@@ -233,7 +233,6 @@ export class AnalogSensorComponent extends Component<
   private handleConfigEnd = () => {
     this.setState({
       ...this.state,
-      expanded: false,
       enableConfiguration: false,
     });
   };
@@ -242,18 +241,15 @@ export class AnalogSensorComponent extends Component<
   private handleConfigBegin = () => {
     this.setState({
       ...this.state,
-      expanded: true,
       enableConfiguration: true,
     });
   };
 
   // Note: use arrow function to properly capture `this`.
   private toggleExpanded = () => {
-    const wasExpanded = this.state.expanded;
-
     this.setState({
       ...this.state,
-      expanded: !wasExpanded,
+      expanded: !this.state.expanded,
       enableConfiguration: false,
     });
   };

--- a/src/ui/preact/system_status_component.tsx
+++ b/src/ui/preact/system_status_component.tsx
@@ -359,6 +359,7 @@ export class SystemStatusComponent
     this.setState({
       ...this.state,
       expanded: !this.state.expanded,
+      enableConfiguration: false,
     });
   };
 
@@ -381,7 +382,6 @@ export class SystemStatusComponent
   private handleConfigEnd = () => {
     this.setState({
       ...this.state,
-      expanded: false,
       enableConfiguration: false,
       config: null,
     });


### PR DESCRIPTION
- Keep the card expanded when configuration is canceled.
- Close the configuration when the card is collapsed.